### PR TITLE
Fix default runtime, add build script and build execution

### DIFF
--- a/es5/lib/components/conanAwsLambda.js
+++ b/es5/lib/components/conanAwsLambda.js
@@ -70,7 +70,7 @@ var ConanAwsLambda = function (_ConanComponent) {
 	function ConanAwsLambda() {
 		_classCallCheck(this, ConanAwsLambda);
 
-		return _possibleConstructorReturn(this, Object.getPrototypeOf(ConanAwsLambda).apply(this, arguments));
+		return _possibleConstructorReturn(this, (ConanAwsLambda.__proto__ || Object.getPrototypeOf(ConanAwsLambda)).apply(this, arguments));
 	}
 
 	_createClass(ConanAwsLambda, [{
@@ -91,7 +91,7 @@ var ConanAwsLambda = function (_ConanComponent) {
 			this.name(name);
 
 			this.handler("handler");
-			this.runtime("nodejs");
+			this.runtime("nodejs4.3");
 			this.memorySize(128);
 			this.timeout(3);
 

--- a/es5/lib/steps/buildPackageStep.js
+++ b/es5/lib/steps/buildPackageStep.js
@@ -8,24 +8,22 @@ function buildPackageStep(conan, context, stepDone) {
 	var conanAwsLambda = context.parameters;
 
 	if (conanAwsLambda.packages() !== undefined) {
-		(function () {
-			var akiro = new context.libraries.Akiro({
-				region: conan.config.region,
-				bucket: conan.config.bucket
-			});
+		var akiro = new context.libraries.Akiro({
+			region: conan.config.region,
+			bucket: conan.config.bucket
+		});
 
-			var tempZipDirectoryPath = context.temporaryDirectoryPath + "/packages";
+		var tempZipDirectoryPath = context.temporaryDirectoryPath + "/packages";
 
-			akiro.package(conanAwsLambda.packages(), tempZipDirectoryPath, function (akiroError) {
-				if (akiroError) {
-					stepDone(akiroError);
-				} else {
-					stepDone(null, {
-						packagesDirectoryPath: tempZipDirectoryPath
-					});
-				}
-			});
-		})();
+		akiro.package(conanAwsLambda.packages(), tempZipDirectoryPath, function (akiroError) {
+			if (akiroError) {
+				stepDone(akiroError);
+			} else {
+				stepDone(null, {
+					packagesDirectoryPath: tempZipDirectoryPath
+				});
+			}
+		});
 	} else {
 		stepDone(null, {
 			packagesDirectoryPath: null

--- a/es5/lib/steps/compileLambdaZipStep.js
+++ b/es5/lib/steps/compileLambdaZipStep.js
@@ -36,8 +36,6 @@ var _hacher2 = _interopRequireDefault(_hacher);
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 // graceful-fs required to avoid file table overflow
-
-
 function relativePath(fullPath, basePath) {
 	var normalizedFullPath = _path2.default.normalize(fullPath);
 
@@ -76,9 +74,9 @@ function compileLambdaZipStep(conan, context, stepDone) {
 
 		lambdaZip.append(lambdaReadStream, { name: lambdaFileName });
 	} else {
-		var lambdaFilePath = relativePath(conanAwsLambda.filePath(), conan.config.basePath);
+		var _lambdaFilePath = relativePath(conanAwsLambda.filePath(), conan.config.basePath);
 
-		var conanHandlerContent = "module.exports = {\n\t" + handlerName + ": require(\"./" + lambdaFilePath + "\")." + handlerName + "\n};\n";
+		var conanHandlerContent = "module.exports = {\n\t" + handlerName + ": require(\"./" + _lambdaFilePath + "\")." + handlerName + "\n};\n";
 
 		var conanHandlerFileName = "conanHandler-" + _hacher2.default.getUUID() + ".js";
 

--- a/es5/lib/steps/createLambdaAliasStep.js
+++ b/es5/lib/steps/createLambdaAliasStep.js
@@ -21,14 +21,14 @@ function createLambdaAliasStep(conan, context, stepDone) {
 	var result = {};
 	_flowsync2.default.eachSeries(aliases, function (alias, next) {
 		var aliasName = alias[0];
-		var aliasVersion = undefined;
+		var aliasVersion = void 0;
 		if (alias.length > 1) {
 			aliasVersion = alias[1];
 		} else {
 			aliasVersion = "$LATEST";
 		}
 
-		var aliasExists = undefined;
+		var aliasExists = void 0;
 		if (context.results.aliases) {
 			aliasExists = context.results.aliases[aliasName];
 		}

--- a/es5/lib/steps/findLambdaAliasStep.js
+++ b/es5/lib/steps/findLambdaAliasStep.js
@@ -21,7 +21,7 @@ function findLambdaAliasStep(conan, context, stepDone) {
 	var result = {};
 	_flowsync2.default.eachSeries(aliases, function (alias, next) {
 		var aliasName = alias[0];
-		var aliasVersion = undefined;
+		var aliasVersion = void 0;
 		if (alias.length > 1) {
 			aliasVersion = alias[1];
 		} else {

--- a/es5/lib/steps/findLambdaByNameStep.js
+++ b/es5/lib/steps/findLambdaByNameStep.js
@@ -9,7 +9,7 @@ function findLambdaByNameStep(conan, context, stepDone) {
 	var lambda = new AWS.Lambda({
 		region: conan.config.region
 	});
-	var lambdaName = undefined;
+	var lambdaName = void 0;
 	if (typeof context.parameters.name === "function") {
 		lambdaName = context.parameters.name();
 	} else {

--- a/es5/lib/steps/updateLambdaAliasStep.js
+++ b/es5/lib/steps/updateLambdaAliasStep.js
@@ -21,7 +21,7 @@ function updateLambdaAliasStep(conan, context, stepDone) {
 	var result = context.results.aliases;
 	_flowsync2.default.eachSeries(aliases, function (alias, next) {
 		var aliasName = alias[0];
-		var aliasVersion = undefined;
+		var aliasVersion = void 0;
 		if (alias.length > 1) {
 			aliasVersion = alias[1];
 		} else {

--- a/es5/lib/steps/validateLambdaStep.js
+++ b/es5/lib/steps/validateLambdaStep.js
@@ -10,8 +10,8 @@ function validateLambdaStep(conan, context, stepDone) {
 		var error = new Error(".role() is a required parameter for a lambda.");
 		stepDone(error);
 	} else if (conanAwsLambda.packages() !== undefined && conan.config.bucket === undefined) {
-		var error = new Error("conan.config.bucket is required to use .packages().");
-		stepDone(error);
+		var _error = new Error("conan.config.bucket is required to use .packages().");
+		stepDone(_error);
 	} else {
 		stepDone();
 	}

--- a/es6/lib/components/conanAwsLambda.js
+++ b/es6/lib/components/conanAwsLambda.js
@@ -46,7 +46,7 @@ export default class ConanAwsLambda extends ConanComponent {
 		this.name(name);
 
 		this.handler("handler");
-		this.runtime("nodejs");
+		this.runtime("nodejs4.3");
 		this.memorySize(128);
 		this.timeout(3);
 

--- a/es6/spec/components/conanAwsLambda.spec.js
+++ b/es6/spec/components/conanAwsLambda.spec.js
@@ -111,8 +111,8 @@ describe("ConanAwsLambda(conan, name)", () => {
 			lambda = new ConanAwsLambda(conan, name, filePath);
 			lambda.handler().should.eql(["handler"]);
 		});
-		it("should set the runtime to 'nodejs' by default", () => {
-			lambda.runtime().should.eql("nodejs");
+		it("should set the runtime to 'nodejs4.3' by default", () => {
+			lambda.runtime().should.eql("nodejs4.3");
 		});
 		it("should set the memorySize to '128' by default", () => {
 			lambda.memorySize().should.eql(128);

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "description": "AWS Lambda plugin for Conan: The Deployer.",
   "main": "es5/lib/conanAwsLambdaPlugin.js",
   "scripts": {
-    "test": "gulp test"
+    "test": "gulp test",
+	"build": "gulp build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This fixes an issue with the default runtime (it was nodejs but now is nodejs4.3) and it throws an error. It is easy to avoid since you can override the runtime, but this just fix the default so you don't need to.

It also adds the build script so a contributor does not need gulp globally installed.

All the differences on the other files are due to changes on transpilation I think, let me know if you want to exclude them. I just executed the build task.